### PR TITLE
Switching from test-framework to Tasty

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project demonstrates how to set up your own real Haskell project, and helps
 * [Tests](#tests)
   * [Unit tests with HUnit](#hunit)
   * [Properties with QuickCheck](#quickcheck)
-  * [test-framework](#test-framework)
+  * [Tasty](#Tasty)
   * [Configuring a test suite](#configuring-a-test-suite-in-cabal)
   * [Running Tests](#running-tests)
   * [doctests](#doctest)
@@ -398,7 +398,7 @@ In Haskell and Cabal there are a _lot_ of different test libraries and framework
 
 * HUnit – a library for writing unit tests
 * QuickCheck – a library for writing properties 
-* test-framework – a framework for organizing and running unit tests and properties
+* Tasty – a framework for organizing and running unit tests and properties
 * doctest – inject tests directly into your documentation
 
 ### HUnit
@@ -418,9 +418,8 @@ I've written a very simple example in `test/UnitTests.hs`* that I think is very 
 ```Haskell
 module UnitTests where
 
-import Test.Framework.Providers.API
-import Test.Framework.Providers.HUnit
-import Test.HUnit
+import Test.Tasty
+import Test.Tasty.HUnit
 
 tests = testGroup "HUnit tests" [
   testCase "a passing test!"       $ 5 @?= 5
@@ -446,8 +445,8 @@ This property is put into a module in `tests/Properties.hs`:
 {-# LANGUAGE TemplateHaskell #-}
 module Properties where
 
-import Test.Framework.Providers.QuickCheck2
-import Test.Framework.TH
+import Test.Tasty.QuickCheck
+import Test.Tasty.TH
 import Test.QuickCheck
 
 prop_list_reverse_reverse :: [Int] -> Bool
@@ -461,21 +460,19 @@ tests = $testGroupGenerator
 
 This module has a couple of very simple properties in it (once again, unrelated to the code in the library). We will see how to run these shortly, as well.
 
-### test-framework
+### Tasty
 
-Before we can run our tests, we need to package them up into a module with a main function. We do that using [test-framework](http://hackage.haskell.org/package/test-framework). Here are the contents of `test/Main.hs`:
+Before we can run our tests, we need to package them up into a module with a main function. We do that using [Tasty](http://hackage.haskell.org/package/tasty). Here are the contents of `test/Main.hs`:
 
 ```Haskell
-module Main where
-
 import Properties
 import UnitTests
-import Test.Framework.Runners.Console (defaultMain)
+import Test.Tasty(defaultMain, testGroup)
 
-main = defaultMain $ [UnitTests.tests, Properties.tests]
+main = defaultMain $ testGroup "All tests" [UnitTests.tests, Properties.tests]
 ```
 
-This module provides a main function using the defaultMain function from test-framework. It takes a list of test groups as an argument, and runs all the tests in those groups. It also takes care of printing fancy messages for successes and failures.
+This module provides a `main` function using the `defaultMain` function from Tasty. It takes a `TestTree` as an argument (constructed using the `testGroup` function to combine the other test modules' `TestTree`s into one), and then it runs all the tests in that combined `TestTree`. It also takes care of printing fancy messages for successes and failures.
 
 ### Configuring a test suite in Cabal
 
@@ -491,10 +488,10 @@ test-suite unit-tests-and-properties
     base,
     HUnit,
     QuickCheck                 >= 2.4,
-    test-framework             >= 0.6,
-    test-framework-hunit,
-    test-framework-quickcheck2 >= 0.2,
-    test-framework-th          >= 0.2
+    tasty                      >= 0.10 && < 0.11,
+    tasty-hunit                >= 0.9 && < 0.10,
+    tasty-quickcheck           >= 0.8 && < 0.9,
+    tasty-th                   >= 0.1 && < 0.2
 ```
 
 Don't worry too much about the details here. Just know that the tests are in the `test` directory, and `Main.hs` is in there. Hopefully soon I'll be able to provide more info here, and/or make the configuration slightly less verbose.
@@ -616,7 +613,7 @@ Testing:
 * http://hunit.sourceforge.net/
 * http://hunit.sourceforge.net/HUnit-1.0/Guide.html
 * http://www.haskell.org/haskellwiki/Introduction_to_QuickCheck2
-* http://hackage.haskell.org/package/test-framework
+* http://hackage.haskell.org/package/tasty
 * https://github.com/sol/doctest-haskell
 
 Books:

--- a/haskell-starter.cabal
+++ b/haskell-starter.cabal
@@ -45,10 +45,10 @@ test-suite unit-tests-and-properties
     base                       >= 4.6 && < 5,
     HUnit                      >= 1.2 && < 1.4,
     QuickCheck                 >= 2.4 && < 2.8,
-    test-framework             >= 0.6 && < 0.9,
-    test-framework-hunit       >= 0.3 && < 0.5,
-    test-framework-quickcheck2 >= 0.2 && < 0.4,
-    test-framework-th          >= 0.2 && < 0.4
+    tasty                      >= 0.10 && < 0.11,
+    tasty-hunit                >= 0.9 && < 0.10,
+    tasty-quickcheck           >= 0.8 && < 0.9,
+    tasty-th                   >= 0.1 && < 0.2
 
 -- doctests
 test-suite doctest

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,6 +2,6 @@ module Main where
 
 import Properties
 import UnitTests
-import Test.Framework.Runners.Console (defaultMain)
+import Test.Tasty(defaultMain, testGroup)
 
-main = defaultMain $ [UnitTests.tests, Properties.tests]
+main = defaultMain $ testGroup "All tests" [UnitTests.tests, Properties.tests]

--- a/test/Properties.hs
+++ b/test/Properties.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Properties where
 
-import Test.Framework.Providers.QuickCheck2
-import Test.Framework.TH
+import Test.Tasty.QuickCheck
+import Test.Tasty.TH
 import Test.QuickCheck
 
 prop_list_reverse_reverse :: [Int] -> Bool

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -1,8 +1,7 @@
 module UnitTests where
 
-import Test.Framework.Providers.API
-import Test.Framework.Providers.HUnit
-import Test.HUnit
+import Test.Tasty
+import Test.Tasty.HUnit
 
 tests = testGroup "HUnit tests" [
   testCase "a passing test!"       $ 5 @?= 5


### PR DESCRIPTION
I recommend pointing newcomers to Tasty rather than test-framework.  test-framework is (more or less) unmaintained, which isn't inherently a problem, but, in practice, using test-framework has caused headaches for me with its outdated dependencies (namely, a forced, transitive dependency upon an old version of MTL).  Tasty seems to have all of the same functionality as test-framework (and then some) and a nearly identical API, all while being actively maintained.
